### PR TITLE
Feature: Add travis nightly and beta builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,8 @@
 language: rust
+rust:
+    - stable
+    - beta
+    - nightly
+matrix:
+    allow_failures:
+        - rust: nightly


### PR DESCRIPTION
the rust team wants things build on beta, so I'm adding nightly and beta builds per the rust travis guide.